### PR TITLE
Added the following: 

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -26,7 +26,7 @@ class Ogre3dConan(ConanFile):
         "direct3d11_renderer": [True, False],
         "opengl_renderer": [True, False],
         "opengl3_renderer": [True, False],
-        #"opengles_renderer": [True, False], # Getting build error: "Cannot open include file 'EGL/egl.h'"
+        "opengles_renderer": [True, False], 
         "codec_freeimage": [True, False],
         "codec_stbi": [True, False],
         "plugin_bsp_scenemanager": [True,False],
@@ -50,7 +50,7 @@ class Ogre3dConan(ConanFile):
         "direct3d11_renderer": False,
         "opengl_renderer": False,
         "opengl3_renderer": False,
-        #"opengles_renderer": False,
+        "opengles_renderer": False,
         "codec_freeimage": True,
         "codec_stbi": True,
         "plugin_bsp_scenemanager": True,
@@ -133,7 +133,9 @@ class Ogre3dConan(ConanFile):
             self.requires("freeimage/3.18.0@utopia/testing")
 
         #if self.options.opengles_renderer:
-            #self.requires("opengl/system") # It seems that the conan package is corrupted, nothing is generated...
+            #self.requires("opengl/system")
+            #if self.settings.os == "Linux":
+            #    self.requires("egl/system")
 
     def source(self):
         tools.replace_in_file("{}/CMakeLists.txt".format(self.folder_name),
@@ -176,8 +178,8 @@ add_compile_definitions(QT_NO_VERSION_TAGGING)'''.format(self.version))
             "ON" if self.options.opengl3_renderer else "OFF"
         cmake.definitions["OGRE_BUILD_RENDERSYSTEM_GL"] = \
             "ON" if self.options.opengl_renderer else "OFF"
-        #cmake.definitions["OGRE_BUILD_RENDERSYSTEM_GLES2"] = \ # Getting build error: "Cannot open include file 'EGL/egl.h'"
-        #    "ON" if self.options.opengles_renderer else "OFF"
+        cmake.definitions["OGRE_BUILD_RENDERSYSTEM_GLES2"] = \
+            "ON" if self.options.opengles_renderer else "OFF"
         if self.settings.compiler == "clang":
             cmake.definitions["CMAKE_EXE_LINKER_FLAGS"] = "-fopenmp=libomp"
 
@@ -225,23 +227,23 @@ add_compile_definitions(QT_NO_VERSION_TAGGING)'''.format(self.version))
         ]
 
         if self.options.codec_freeimage:
-            libs.append("Codec_FreeImage");
+            libs.append("Codec_FreeImage")
         if self.options.codec_stbi:
-            libs.append("Codec_STBI");
+            libs.append("Codec_STBI")
 
         if self.options.plugin_bsp_scenemanager:
-            libs.append("Plugin_BSPSceneManager");
+            libs.append("Plugin_BSPSceneManager")
         if self.options.plugin_octree:
-            libs.append("Plugin_OctreeSceneManager");
+            libs.append("Plugin_OctreeSceneManager")
         if self.options.plugin_particlefx:
-            libs.append("Plugin_ParticleFX");
+            libs.append("Plugin_ParticleFX")
         if self.options.plugin_dotscene:
-            libs.append("Plugin_DotScene");
+            libs.append("Plugin_DotScene")
         if self.options.with_cg:
-            libs.append("Plugin_CgProgramManager");
+            libs.append("Plugin_CgProgramManager")
         if self.options.plugin_pcz_scenemanager:
-            libs.append("Plugin_PCZSceneManager");
-            libs.append("Plugin_OctreeZone");
+            libs.append("Plugin_PCZSceneManager")
+            libs.append("Plugin_OctreeZone")
 
         if self.options.opengl_renderer:
             libs.append("RenderSystem_GL")
@@ -251,9 +253,9 @@ add_compile_definitions(QT_NO_VERSION_TAGGING)'''.format(self.version))
             libs.append("RenderSystem_Direct3D9")
         if self.options.direct3d11_renderer:
             libs.append("RenderSystem_Direct3D11")
-        #if self.options.opengles_renderer:
-        #    libs.append("RenderSystem_GLES2")
-        if self.options.opengl_renderer or self.options.opengl3_renderer:# or self.options.opengles_renderer:
+        if self.options.opengles_renderer:
+            libs.append("RenderSystem_GLES2")
+        if self.options.opengl_renderer or self.options.opengl3_renderer or self.options.opengles_renderer:
             libs.append("OgreGLSupport")
 
         if self.options.bites:
@@ -276,9 +278,9 @@ add_compile_definitions(QT_NO_VERSION_TAGGING)'''.format(self.version))
             self.cpp_info.includedirs.append("include/OGRE/Bites")
             
         if self.options.codec_freeimage:
-            self.cpp_info.includedirs.append("include/OGRE/Plugins/FreeImageCodec");
+            self.cpp_info.includedirs.append("include/OGRE/Plugins/FreeImageCodec")
         if self.options.codec_stbi:
-            self.cpp_info.includedirs.append("include/OGRE/Plugins/STBICodec");
+            self.cpp_info.includedirs.append("include/OGRE/Plugins/STBICodec")
 
         if self.options.opengl_renderer:
             self.cpp_info.includedirs.append("include/OGRE/RenderSystems/GL")
@@ -289,22 +291,22 @@ add_compile_definitions(QT_NO_VERSION_TAGGING)'''.format(self.version))
             self.cpp_info.includedirs.append("include/OGRE/RenderSystems/Direct3D9")
         if self.options.direct3d11_renderer:
             self.cpp_info.includedirs.append("include/OGRE/RenderSystems/Direct3D11")
-        #if self.options.opengles_renderer:
-        #    self.cpp_info.includedirs.append("include/OGRE/RenderSystems/GLES2")
+        if self.options.opengles_renderer:
+            self.cpp_info.includedirs.append("include/OGRE/RenderSystems/GLES2")
 
         if self.options.plugin_bsp_scenemanager:
-            self.cpp_info.includedirs.append("include/OGRE/Plugins/BSPSceneManager");
+            self.cpp_info.includedirs.append("include/OGRE/Plugins/BSPSceneManager")
         if self.options.plugin_octree:
-            self.cpp_info.includedirs.append("include/OGRE/Plugins/OctreeSceneManager");
+            self.cpp_info.includedirs.append("include/OGRE/Plugins/OctreeSceneManager")
         if self.options.plugin_particlefx:
-            self.cpp_info.includedirs.append("include/OGRE/Plugins/ParticleFX");
+            self.cpp_info.includedirs.append("include/OGRE/Plugins/ParticleFX")
         if self.options.plugin_dotscene:
-            self.cpp_info.includedirs.append("include/OGRE/Plugins/DotScene");
+            self.cpp_info.includedirs.append("include/OGRE/Plugins/DotScene")
         if self.options.with_cg:
-            self.cpp_info.includedirs.append("include/OGRE/Plugins/CgProgramManager");
+            self.cpp_info.includedirs.append("include/OGRE/Plugins/CgProgramManager")
         if self.options.plugin_pcz_scenemanager:
-            self.cpp_info.includedirs.append("include/OGRE/Plugins/PCZSceneManager");
-            self.cpp_info.includedirs.append("include/OGRE/Plugins/OctreeZone");
+            self.cpp_info.includedirs.append("include/OGRE/Plugins/PCZSceneManager")
+            self.cpp_info.includedirs.append("include/OGRE/Plugins/OctreeZone")
 
         if self.settings.compiler == "clang":
             self.cpp_info.exelinkflags = ["-fopenmp=libomp"]

--- a/conanfile.py
+++ b/conanfile.py
@@ -26,7 +26,14 @@ class Ogre3dConan(ConanFile):
         "direct3d11_renderer": [True, False],
         "opengl_renderer": [True, False],
         "opengl3_renderer": [True, False],
-        "opengles_renderer": [True, False],
+        #"opengles_renderer": [True, False], # Getting build error: "Cannot open include file 'EGL/egl.h'"
+        "codec_freeimage": [True, False],
+        "codec_stbi": [True, False],
+        "plugin_bsp_scenemanager": [True,False],
+        "plugin_octree": [True,False],
+        "plugin_particlefx": [True,False],
+        "plugin_dotscene": [True,False],
+        "plugin_pcz_scenemanager": [True,False],
         }
 
     default_options = {
@@ -43,7 +50,14 @@ class Ogre3dConan(ConanFile):
         "direct3d11_renderer": False,
         "opengl_renderer": False,
         "opengl3_renderer": False,
-        "opengles_renderer": False,
+        #"opengles_renderer": False,
+        "codec_freeimage": True,
+        "codec_stbi": True,
+        "plugin_bsp_scenemanager": True,
+        "plugin_octree": True,
+        "plugin_particlefx": True,
+        "plugin_dotscene": True,
+        "plugin_pcz_scenemanager": True,
         }
 
     generators = "cmake"
@@ -57,7 +71,6 @@ class Ogre3dConan(ConanFile):
         ("sdl2/2.0.10@bincrafters/stable"),
         ("zziplib/0.13.69@utopia/testing"),
         # ("ois/1.5@utopia/testing"), # for older versions
-        ("freeimage/3.18.0@utopia/testing"),
     ]
 
     folder_name = "ogre-{}".format(version)
@@ -102,16 +115,25 @@ class Ogre3dConan(ConanFile):
             self.requires("poco/1.9.4")
 
         if self.options.with_qt:
-            self.options["sdl2"].fPIC = True
+            if self.settings.compiler != 'Visual Studio':
+                self.options["sdl2"].fPIC = True
             self.requires("qt/5.15.1@bincrafters/stable")
             self.requires("libjpeg/9d")
-
+        
+        if self.options.bites and self.settings.compiler != 'Visual Studio':
+            self.options["sdl2"].fPIC = True
 
         if self.options.with_cg:
             self.requires("nvidia-cg-toolkit-binaries/3.1.0013@utopia/testing")
 
         if self.settings.os == "Linux" and self.options.bites:
             self.requires("libxaw/1.0.13@bincrafters/stable")
+
+        if self.options.codec_freeimage:
+            self.requires("freeimage/3.18.0@utopia/testing")
+
+        #if self.options.opengles_renderer:
+            #self.requires("opengl/system") # It seems that the conan package is corrupted, nothing is generated...
 
     def source(self):
         tools.replace_in_file("{}/CMakeLists.txt".format(self.folder_name),
@@ -154,10 +176,26 @@ add_compile_definitions(QT_NO_VERSION_TAGGING)'''.format(self.version))
             "ON" if self.options.opengl3_renderer else "OFF"
         cmake.definitions["OGRE_BUILD_RENDERSYSTEM_GL"] = \
             "ON" if self.options.opengl_renderer else "OFF"
-        cmake.definitions["OGRE_BUILD_RENDERSYSTEM_GLES2"] = \
-            "ON" if self.options.opengles_renderer else "OFF"
+        #cmake.definitions["OGRE_BUILD_RENDERSYSTEM_GLES2"] = \ # Getting build error: "Cannot open include file 'EGL/egl.h'"
+        #    "ON" if self.options.opengles_renderer else "OFF"
         if self.settings.compiler == "clang":
             cmake.definitions["CMAKE_EXE_LINKER_FLAGS"] = "-fopenmp=libomp"
+
+        cmake.definitions["Build_FreeImage_codec."] = \
+            "ON" if self.options.codec_freeimage else "OFF"
+        cmake.definitions["Enable_STBI_image_codec."] = \
+            "ON" if self.options.codec_stbi else "OFF"
+
+        cmake.definitions["Build_BSP_SceneManager_plugin"] = \
+            "ON" if self.options.plugin_bsp_scenemanager else "OFF"
+        cmake.definitions["Build_Octree_SceneManager_plugin"] = \
+            "ON" if self.options.plugin_octree else "OFF"
+        cmake.definitions["Build_ParticleFX_plugin"] = \
+            "ON" if self.options.plugin_particlefx else "OFF"
+        cmake.definitions["Build_.scene_plugin"] = \
+            "ON" if self.options.plugin_dotscene else "OFF"
+        cmake.definitions["Build_PCZ_SceneManager_plugin"] = \
+            "ON" if self.options.plugin_pcz_scenemanager else "OFF"
 
         cmake.configure(source_folder=self.folder_name)
         return cmake
@@ -174,6 +212,7 @@ add_compile_definitions(QT_NO_VERSION_TAGGING)'''.format(self.version))
 
     def package_info(self):
         self.cpp_info.name = 'Ogre3D'
+        self.cpp_info.libdirs = ['lib', 'lib/OGRE']
         libs = [
             "OgreMain",
             "OgreOverlay",
@@ -182,7 +221,40 @@ add_compile_definitions(QT_NO_VERSION_TAGGING)'''.format(self.version))
             "OgreRTShaderSystem",
             "OgreTerrain",
             "OgreVolume",
+            "OgreMeshLodGenerator",
         ]
+
+        if self.options.codec_freeimage:
+            libs.append("Codec_FreeImage");
+        if self.options.codec_stbi:
+            libs.append("Codec_STBI");
+
+        if self.options.plugin_bsp_scenemanager:
+            libs.append("Plugin_BSPSceneManager");
+        if self.options.plugin_octree:
+            libs.append("Plugin_OctreeSceneManager");
+        if self.options.plugin_particlefx:
+            libs.append("Plugin_ParticleFX");
+        if self.options.plugin_dotscene:
+            libs.append("Plugin_DotScene");
+        if self.options.with_cg:
+            libs.append("Plugin_CgProgramManager");
+        if self.options.plugin_pcz_scenemanager:
+            libs.append("Plugin_PCZSceneManager");
+            libs.append("Plugin_OctreeZone");
+
+        if self.options.opengl_renderer:
+            libs.append("RenderSystem_GL")
+        if self.options.opengl3_renderer:
+            libs.append("RenderSystem_GL3Plus")
+        if self.options.direct3d9_renderer:
+            libs.append("RenderSystem_Direct3D9")
+        if self.options.direct3d11_renderer:
+            libs.append("RenderSystem_Direct3D11")
+        #if self.options.opengles_renderer:
+        #    libs.append("RenderSystem_GLES2")
+        if self.options.opengl_renderer or self.options.opengl3_renderer:# or self.options.opengles_renderer:
+            libs.append("OgreGLSupport")
 
         if self.options.bites:
             libs.append("OgreBites")
@@ -197,9 +269,42 @@ add_compile_definitions(QT_NO_VERSION_TAGGING)'''.format(self.version))
             "include/OGRE/RTShaderSystem",
             "include/OGRE/Terrain",
             "include/OGRE/Volume",
+            "include/OGRE/Threading",
+            "include/OGRE/MeshLodGenerator",
         ])
         if self.options.bites:
             self.cpp_info.includedirs.append("include/OGRE/Bites")
+            
+        if self.options.codec_freeimage:
+            self.cpp_info.includedirs.append("include/OGRE/Plugins/FreeImageCodec");
+        if self.options.codec_stbi:
+            self.cpp_info.includedirs.append("include/OGRE/Plugins/STBICodec");
+
+        if self.options.opengl_renderer:
+            self.cpp_info.includedirs.append("include/OGRE/RenderSystems/GL")
+            self.cpp_info.includedirs.append("include/OGRE/RenderSystems/GL/GL")
+        if self.options.opengl3_renderer:
+            self.cpp_info.includedirs.append("include/OGRE/RenderSystems/GL3Plus")
+        if self.options.direct3d9_renderer:
+            self.cpp_info.includedirs.append("include/OGRE/RenderSystems/Direct3D9")
+        if self.options.direct3d11_renderer:
+            self.cpp_info.includedirs.append("include/OGRE/RenderSystems/Direct3D11")
+        #if self.options.opengles_renderer:
+        #    self.cpp_info.includedirs.append("include/OGRE/RenderSystems/GLES2")
+
+        if self.options.plugin_bsp_scenemanager:
+            self.cpp_info.includedirs.append("include/OGRE/Plugins/BSPSceneManager");
+        if self.options.plugin_octree:
+            self.cpp_info.includedirs.append("include/OGRE/Plugins/OctreeSceneManager");
+        if self.options.plugin_particlefx:
+            self.cpp_info.includedirs.append("include/OGRE/Plugins/ParticleFX");
+        if self.options.plugin_dotscene:
+            self.cpp_info.includedirs.append("include/OGRE/Plugins/DotScene");
+        if self.options.with_cg:
+            self.cpp_info.includedirs.append("include/OGRE/Plugins/CgProgramManager");
+        if self.options.plugin_pcz_scenemanager:
+            self.cpp_info.includedirs.append("include/OGRE/Plugins/PCZSceneManager");
+            self.cpp_info.includedirs.append("include/OGRE/Plugins/OctreeZone");
 
         if self.settings.compiler == "clang":
             self.cpp_info.exelinkflags = ["-fopenmp=libomp"]


### PR DESCRIPTION
1) Use fPIC in sdl2 when compiling with bites and Linux 
2) Options to include plugins and codecs, which is set true by default in Ogres CMakeLists.txt 
3) Missing libraries and includes (mainly generated by plugins/codecs/renderers are added to the package info. 

Known bug: Cannot include file EGL/egl.h when compiling with OpenGLES. OpenGLES option is therefore commented out.