### PR TITLE
Add 14.4.1 and update msvc 194

### DIFF
--- a/.github/workflows/ci-conan-clang.yml
+++ b/.github/workflows/ci-conan-clang.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [14.1.1, 14.3.4]
+        version: [14.3.4, 14.4.1]
         build_type: [Debug, Release]
         profile: [clang]
         compiler_version: [14]

--- a/.github/workflows/ci-conan-gcc.yml
+++ b/.github/workflows/ci-conan-gcc.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [14.1.1, 14.3.4]
+        version: [14.3.4, 14.4.1]
         configs: ["default", "fhsim"]
         build_type: [Debug, Release]
         profile: [gcc]

--- a/.github/workflows/ci-conan-msvc.yml
+++ b/.github/workflows/ci-conan-msvc.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [14.1.1, 14.3.4]
+        version: [14.3.4, 14.4.1]
         configs: ["default", "fhsim"]
         build_type: [Debug, Release]
         profile: [msvc17]

--- a/conandata.yml
+++ b/conandata.yml
@@ -34,7 +34,7 @@ dependencies:
     pugixml: 1.14  # Assimp issue
     qt5: "[>=5.15 <6]"
     qt6: "[>=6.1]"
-    sdl: "[>=2.28.0 <2.33]"
+    sdl: "2.32.8"
     swig: "[>=4 <5]"
     vulkan-loader: 1.4.313.0
     xkbcommon: 1.6.0

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,5 +1,9 @@
 ---
 sources:
+  14.4.1:
+    sha256: 1c1d5d48b26acf8dd3f32fcb4cafd1216f9fe3a2ceec260ec086926651ad74de
+    url:
+      - https://github.com/OGRECave/ogre/archive/refs/tags/v14.4.1.tar.gz
   14.3.4:
     sha256: 0c74e6ca7bb920ff59c5da8a359e6d96215c7804261301feec4f2e54f206b27d
     url:
@@ -14,6 +18,30 @@ sources:
       - https://github.com/OGRECave/ogre/archive/refs/tags/v13.6.5.tar.gz
 
 dependencies:
+  14.4.1:
+    assimp: 5.4.3  # 6.0.2 should be used
+    bullet3: 3.25
+    egl: system
+    freeimage: 3.18.0
+    freetype: 2.13.3
+    glslang: 11.7.0
+    gtest: 1.16.0
+    cmake: "[>=3.16 <4]"
+    imgui: "[<1.92]"  # Pinned until new features are applied in Ogre
+    openexr: 2.5.9
+    opengl: system
+    openssl: "[>=1.1 <4]"
+    pugixml: 1.14  # Assimp issue
+    qt5: "[>=5.15 <6]"
+    qt6: "[>=6.1]"
+    sdl: "[>=2.28.0 <2.33]"
+    swig: "[>=4 <5]"
+    vulkan-loader: 1.4.313.0
+    xkbcommon: 1.6.0
+    xorg: system
+    zlib: "[>=1.2.11 <2]"
+    libjpeg: 9f
+    libpng: 1.6.50
   14.3.4:
     assimp: 5.4.3
     bullet3: 3.25
@@ -87,6 +115,10 @@ dependencies:
     libpng: 1.6.46
 
 patches:
+  14.4.1:
+    - patch_file: patches/14.4.1-0001-Set-rpath-with-origin-variants.patch
+    - patch_file: patches/14.4.1-0002-Remove-absolute-paths-from-ogre-config.patch
+    - patch_file: patches/14.4.1-0003-Do-conanization-fixes.patch
   14.3.4:
     - patch_file: patches/14.3.4-0001-Set-rpath-with-origin-variants.patch
     - patch_file: patches/14.3.4-0002-Remove-absolute-paths-from-ogre-config.patch

--- a/patches/14.4.1-0001-Set-rpath-with-origin-variants.patch
+++ b/patches/14.4.1-0001-Set-rpath-with-origin-variants.patch
@@ -1,0 +1,27 @@
+From 0c6d0cd6b689eff3cf90b3b1fae40b452d09d6d9 Mon Sep 17 00:00:00 2001
+From: Joakim Haugen <joakim.haugen@sintef.no>
+Date: Fri, 24 Oct 2025 15:05:15 +0200
+Subject: [PATCH 1/3] Set rpath with origin variants
+
+---
+ CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 380d59138..e8b0f339d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -420,8 +420,8 @@ mark_as_advanced(
+ ###################################################################
+ include(ConfigureBuild)
+ 
+-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH};${CMAKE_INSTALL_PREFIX}/${OGRE_LIB_DIRECTORY}")
+-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
++set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH};$ORIGIN;$ORIGIN/..;$ORIGIN/../lib;$ORIGIN/../lib/OGRE;$ORIGIN/../..")
++set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
+ 
+ ###################################################################
+ # disable way too common compiler warnings on project level
+-- 
+2.39.5
+

--- a/patches/14.4.1-0002-Remove-absolute-paths-from-ogre-config.patch
+++ b/patches/14.4.1-0002-Remove-absolute-paths-from-ogre-config.patch
@@ -1,0 +1,87 @@
+From aab7c6168b99ee42b8effd9ebc1ab609de6150ae Mon Sep 17 00:00:00 2001
+From: Joakim Haugen <joakim.haugen@sintef.no>
+Date: Fri, 24 Oct 2025 15:11:35 +0200
+Subject: [PATCH 2/3] Remove absolute paths from ogre config
+
+---
+ CMake/InstallResources.cmake                 | 12 ++++++------
+ CMake/Templates/OgreConfigPaths.h.in         |  6 +++---
+ Components/Bites/src/OgreGLXConfigDialog.cpp |  3 +--
+ 3 files changed, 10 insertions(+), 11 deletions(-)
+
+diff --git a/CMake/InstallResources.cmake b/CMake/InstallResources.cmake
+index e24d9fa1b..75e0d198f 100644
+--- a/CMake/InstallResources.cmake
++++ b/CMake/InstallResources.cmake
+@@ -33,10 +33,10 @@ endif()
+ if (NOT OGRE_PLUGINS_PATH)
+   if (WIN32)
+     set(OGRE_PLUGINS_PATH "${OGRE_BIN_DIRECTORY}")
+-    set(OGRE_PLUGIN_DIR_REL "${CMAKE_INSTALL_PREFIX}/${OGRE_BIN_DIRECTORY}")
++    set(OGRE_PLUGIN_DIR_REL "../${OGRE_BIN_DIRECTORY}")
+   else ()
+     set(OGRE_PLUGINS_PATH "${OGRE_LIB_DIRECTORY}/OGRE")
+-    set(OGRE_PLUGIN_DIR_REL "${CMAKE_INSTALL_PREFIX}/${OGRE_LIB_DIRECTORY}/OGRE")
++    set(OGRE_PLUGIN_DIR_REL "../../${OGRE_LIB_DIRECTORY}/OGRE")
+   endif()
+ else ()
+   set(OGRE_PLUGIN_DIR_REL "${CMAKE_INSTALL_PREFIX}/${OGRE_PLUGINS_PATH}")
+@@ -63,8 +63,8 @@ elseif (APPLE)
+   set(OGRE_SAMPLES_DIR_REL "Contents/Plugins/")
+   set(OGRE_CFG_INSTALL_PATH "bin")
+ elseif (UNIX)
+-  set(OGRE_TEST_MEDIA_DIR_REL "${CMAKE_INSTALL_PREFIX}/Tests/Media")
+-  set(OGRE_SAMPLES_DIR_REL "${CMAKE_INSTALL_PREFIX}/${OGRE_LIB_DIRECTORY}/OGRE/Samples")
++  set(OGRE_TEST_MEDIA_DIR_REL "../../Tests/Media")
++  set(OGRE_SAMPLES_DIR_REL "../${OGRE_LIB_DIRECTORY}/OGRE/Samples")
+ endif ()
+ 
+ # generate OgreConfigPaths.h
+@@ -248,8 +248,8 @@ configure_package_config_file(${OGRE_TEMPLATES_DIR}/OGREConfig.cmake.in ${PROJEC
+     INSTALL_DESTINATION ${OGRE_CMAKE_DIR}
+     PATH_VARS OGRE_MEDIA_PATH OGRE_PLUGINS_PATH OGRE_CFG_INSTALL_PATH CMAKE_INSTALL_PREFIX)
+ write_basic_package_version_file(
+-    ${PROJECT_BINARY_DIR}/cmake/OGREConfigVersion.cmake 
+-    VERSION ${OGRE_VERSION} 
++    ${PROJECT_BINARY_DIR}/cmake/OGREConfigVersion.cmake
++    VERSION ${OGRE_VERSION}
+     COMPATIBILITY SameMajorVersion)
+ install(FILES
+    ${PROJECT_BINARY_DIR}/cmake/OGREConfig.cmake
+diff --git a/CMake/Templates/OgreConfigPaths.h.in b/CMake/Templates/OgreConfigPaths.h.in
+index d51aab547..e139f5922 100644
+--- a/CMake/Templates/OgreConfigPaths.h.in
++++ b/CMake/Templates/OgreConfigPaths.h.in
+@@ -1,8 +1,8 @@
+ #ifndef OGRECONFIGPATHS_H_
+ #define OGRECONFIGPATHS_H_
+ 
+-#define OGRE_CONFIG_DIR "@CMAKE_INSTALL_PREFIX@/@OGRE_CFG_INSTALL_PATH@"
+-#define OGRE_MEDIA_DIR "@CMAKE_INSTALL_PREFIX@/@OGRE_MEDIA_PATH@"
+-#define OGRE_PLUGIN_DIR "@OGRE_PLUGIN_DIR_REL@" 
++#define OGRE_CONFIG_DIR "@OGRE_CFG_INSTALL_PATH@"
++#define OGRE_MEDIA_DIR "@OGRE_MEDIA_PATH_REL@"
++#define OGRE_PLUGIN_DIR "@OGRE_PLUGIN_DIR_REL@"
+ 
+ #endif /* OGRECONFIGPATHS_H_ */
+diff --git a/Components/Bites/src/OgreGLXConfigDialog.cpp b/Components/Bites/src/OgreGLXConfigDialog.cpp
+index 9ce1157e3..02ad00846 100644
+--- a/Components/Bites/src/OgreGLXConfigDialog.cpp
++++ b/Components/Bites/src/OgreGLXConfigDialog.cpp
+@@ -337,7 +337,7 @@ Pixmap GLXConfigurator::CreateBackdrop(Window rootWindow, int depth) {
+         Image img;
+ 
+         // Load backdrop image using OGRE
+-        String path = FileSystemLayer::resolveBundlePath(OGRE_MEDIA_DIR "/../GLX_backdrop.png");
++        String path = FileSystemLayer::resolveBundlePath("../" OGRE_MEDIA_DIR "/GLX_backdrop.png");
+         DataStreamPtr imgStreamPtr = Root::openFileStream(path);
+         img.load(imgStreamPtr, "png");
+ 
+@@ -501,4 +501,3 @@ bool ConfigDialog::display()
+     return true;
+ }
+ }
+-
+-- 
+2.39.5
+

--- a/patches/14.4.1-0003-Do-conanization-fixes.patch
+++ b/patches/14.4.1-0003-Do-conanization-fixes.patch
@@ -1,0 +1,369 @@
+From 87cfd5323dcf3926daf378fa9fdb76aca6a137f6 Mon Sep 17 00:00:00 2001
+From: Joakim Haugen <joakim.haugen@sintef.no>
+Date: Fri, 24 Oct 2025 15:37:28 +0200
+Subject: [PATCH 3/3] Do conanization fixes
+
+---
+ CMake/Dependencies.cmake              | 60 +++++++++++++--------------
+ CMake/Utils/MacroLogFeature.cmake     |  2 +-
+ CMakeLists.txt                        | 11 ++++-
+ Components/Overlay/CMakeLists.txt     | 12 ++++--
+ PlugIns/Assimp/CMakeLists.txt         |  2 +-
+ PlugIns/FreeImageCodec/CMakeLists.txt |  6 +--
+ PlugIns/GLSLang/CMakeLists.txt        | 33 +++++----------
+ RenderSystems/Vulkan/CMakeLists.txt   |  5 +--
+ Tests/CMakeLists.txt                  |  2 +-
+ Tools/AssimpConverter/CMakeLists.txt  |  2 +-
+ 10 files changed, 66 insertions(+), 69 deletions(-)
+
+diff --git a/CMake/Dependencies.cmake b/CMake/Dependencies.cmake
+index fb7c1f07c..af2695369 100644
+--- a/CMake/Dependencies.cmake
++++ b/CMake/Dependencies.cmake
+@@ -80,10 +80,6 @@ if (UNIX AND NOT EMSCRIPTEN)
+   set(OGRE_DEP_SEARCH_PATH ${OGRE_DEP_SEARCH_PATH} /usr/lib/${CMAKE_SYSTEM_PROCESSOR}-linux-gnu)
+ endif ()
+ 
+-# give guesses as hints to the find_package calls
+-set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${OGRE_DEP_SEARCH_PATH})
+-set(CMAKE_FRAMEWORK_PATH ${CMAKE_FRAMEWORK_PATH} ${OGRE_DEP_SEARCH_PATH})
+-
+ if(OGRE_BUILD_DEPENDENCIES AND NOT EXISTS ${OGREDEPS_PATH})
+     message(STATUS "Building pugixml")
+     file(DOWNLOAD
+@@ -216,8 +212,10 @@ find_package(FreeImage)
+ macro_log_feature(FreeImage_FOUND "freeimage" "Support for commonly used graphics image formats" "http://freeimage.sourceforge.net")
+ 
+ # Find FreeType
+-find_package(Freetype)
+-macro_log_feature(FREETYPE_FOUND "freetype" "Portable font engine" "http://www.freetype.org")
++if(OGRE_WITH_FREETYPE)
++  find_package(Freetype REQUIRED)
++endif()
++macro_log_feature(Freetype_FOUND "freetype" "Portable font engine" "http://www.freetype.org")
+ 
+ # Find X11
+ if (UNIX AND NOT APPLE AND NOT ANDROID AND NOT EMSCRIPTEN)
+@@ -275,12 +273,17 @@ endif()
+ 
+ # Find Cg
+ if (NOT (APPLE_IOS OR WINDOWS_STORE OR WINDOWS_PHONE OR ANDROID OR EMSCRIPTEN))
+-  find_package(Cg)
++  find_package(Cg QUIET)
+   macro_log_feature(Cg_FOUND "cg" "C for graphics shader language" "http://developer.nvidia.com/object/cg_toolkit.html")
+ endif ()
+ 
++find_package( SPIRV-Tools QUIET CONFIG)
++find_package(glslang QUIET)
++find_package(Vulkan QUIET)
++find_package(VulkanHeaders QUIET)
++
+ # Find Vulkan SDK
+-macro_log_feature(ENV{VULKAN_SDK} "Vulkan SDK" "Vulkan RenderSystem, glslang Plugin. Alternatively use system packages" "https://vulkan.lunarg.com/")
++macro_log_feature(Vulkan_FOUND "Vulkan SDK" "Vulkan RenderSystem, glslang Plugin. Alternatively use system packages" "https://vulkan.lunarg.com/")
+ 
+ # OpenEXR
+ find_package(OpenEXR)
+@@ -293,7 +296,7 @@ find_package(PythonLibs)
+ macro_log_feature(PYTHONLIBS_FOUND "Python" "Language bindings to use OGRE from Python" "http://www.python.org/")
+ 
+ # SWIG
+-find_package(SWIG 3.0.8 QUIET)
++find_package(SWIG QUIET)
+ macro_log_feature(SWIG_FOUND "SWIG" "Language bindings (Python, Java, C#) for OGRE" "http://www.swig.org/")
+ 
+ # pugixml
+@@ -301,7 +304,7 @@ find_package(pugixml QUIET)
+ macro_log_feature(pugixml_FOUND "pugixml" "Needed for XMLConverter and DotScene Plugin" "https://pugixml.org/")
+ 
+ # Find zlib
+-find_package(ZLIB)
++find_package(ZLIB QUIET)
+ macro_log_feature(ZLIB_FOUND "zlib" "Simple data compression library" "http://www.zlib.net")
+ 
+ # Assimp
+@@ -312,17 +315,6 @@ macro_log_feature(assimp_FOUND "Assimp" "Needed for the AssimpLoader Plugin" "ht
+ find_package(Bullet QUIET)
+ macro_log_feature(BULLET_FOUND "Bullet" "Bullet physics" "https://pybullet.org")
+ 
+-if(assimp_FOUND)
+-  # workaround horribly broken assimp cmake, fixed with assimp 5.1
+-  add_library(fix::assimp INTERFACE IMPORTED)
+-  set_target_properties(fix::assimp PROPERTIES
+-      INTERFACE_LINK_LIBRARIES "${ASSIMP_LIBRARIES};pugixml"
+-      INTERFACE_LINK_DIRECTORIES "${ASSIMP_LIBRARY_DIRS}"
+-  )
+-  if(EXISTS "${ASSIMP_INCLUDE_DIRS}")
+-    set_target_properties(fix::assimp PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${ASSIMP_INCLUDE_DIRS}")
+-  endif()
+-endif()
+ 
+ #######################################################################
+ # Samples dependencies
+@@ -331,18 +323,26 @@ endif()
+ # Find sdl2
+ if(NOT ANDROID AND NOT EMSCRIPTEN)
+   # find script does not work in cross compilation environment
+-  find_package(SDL2 QUIET)
+-  macro_log_feature(SDL2_FOUND "SDL2" "Simple DirectMedia Library needed for input handling in samples" "https://www.libsdl.org/")
+-  if(SDL2_FOUND AND NOT TARGET SDL2::SDL2)
+-    add_library(SDL2::SDL2 INTERFACE IMPORTED)
+-    set_target_properties(SDL2::SDL2 PROPERTIES
++  if(OGRE_WITH_SDL)
++    find_package(SDL2)
++    macro_log_feature(SDL2_FOUND "SDL2" "Simple DirectMedia Library needed for input handling in samples" "https://www.libsdl.org/")
++    if(SDL2_FOUND AND NOT TARGET SDL2::SDL2)
++      add_library(SDL2::SDL2 INTERFACE IMPORTED)
++      set_target_properties(SDL2::SDL2 PROPERTIES
+         INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIRS}"
+         INTERFACE_LINK_LIBRARIES "${SDL2_LIBRARIES}"
+-    )
++      )
++    endif()
++  else()
++    set(SDL2_FOUND OFF)
+   endif()
+ 
+-  find_package(QT NAMES Qt6 Qt5 COMPONENTS Core Gui QUIET CONFIG)
+-  find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Gui QUIET CONFIG)
++  if(OGRE_WITH_QT)
++    find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Gui QUIET CONFIG)
++    set(QT_FOUND ON)
++  else()
++    set(QT_FOUND OFF)
++  endif()
+ 
+   macro_log_feature(QT_FOUND "Qt" "optional integration with the Qt Library for window creation and input" "http://www.qt.io/")
+ endif()
+@@ -355,5 +355,5 @@ find_package(Doxygen QUIET)
+ macro_log_feature(DOXYGEN_FOUND "Doxygen" "Tool for building API documentation" "http://doxygen.org")
+ 
+ # Find Softimage SDK
+-find_package(Softimage)
++find_package(Softimage QUIET)
+ macro_log_feature(Softimage_FOUND "Softimage" "Softimage SDK needed for building XSIExporter" "")
+diff --git a/CMake/Utils/MacroLogFeature.cmake b/CMake/Utils/MacroLogFeature.cmake
+index af0d3a125..605a72eb6 100644
+--- a/CMake/Utils/MacroLogFeature.cmake
++++ b/CMake/Utils/MacroLogFeature.cmake
+@@ -110,7 +110,7 @@ MACRO(MACRO_DISPLAY_FEATURE_LOG)
+       SET(_elist 1)
+       FILE(READ ${_file} _enabled)
+       FILE(REMOVE ${_file})
+-      SET(_summary "${_summary}-----------------------------------------------------------------------------\n-- The following external packages were located on your system.\n-- This installation will have the extra features provided by these packages, unless disabled.\n${_enabled}")
++      SET(_summary "${_summary}-----------------------------------------------------------------------------\n-- The following external packages were located on your system.\n-- This installation will have the extra features provided by these packages, but only if you specified the corresponding conan option.\n${_enabled}")
+    ENDIF (EXISTS ${_file})
+ 
+    SET(_dlist 0)
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e8b0f339d..39ff4ca54 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -64,6 +64,7 @@ if (APPLE AND NOT ANDROID AND NOT EMSCRIPTEN AND NOT ANDROID_PLATFORM)
+ endif ()
+ 
+ project(OGRE VERSION 14.4.1)
++add_compile_definitions(QT_NO_VERSION_TAGGING)
+ 
+ # extra version info
+ set(OGRE_VERSION_SUFFIX "")
+@@ -193,11 +194,15 @@ if((CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU") AND NOT OGRE_STATIC)
+ endif()
+ 
+ # determine system endianness
+-if (MSVC OR ANDROID OR EMSCRIPTEN OR APPLE_IOS)
++if (MSVC OR ANDROID OR EMSCRIPTEN OR APPLE_IOS OR QT_VERSION_MAJOR STREQUAL 6)
+   # This doesn't work on VS 2010
+   # MSVC only builds for intel anyway
+   # all IOS devices are little endian
+   set(OGRE_TEST_BIG_ENDIAN FALSE)
++  # Test may fail if Qt6 is a requirement, untested recently, though..
++  if(QT_VERSION_MAJOR STREQUAL 6)
++    message(WARNING "OGRE_TEST_BIG_ENDIAN set to FALSE without testing")
++  endif()
+ else()
+   include(TestBigEndian)
+   test_big_endian(OGRE_TEST_BIG_ENDIAN)
+@@ -314,6 +319,10 @@ cmake_dependent_option(OGRE_BUILD_PLUGIN_CG "Build Cg plugin" TRUE "Cg_FOUND;NOT
+ option(OGRE_BUILD_PLUGIN_GLSLANG "Build glslang plugin" ${OGRE_BUILD_RENDERSYSTEM_VULKAN}) # no way to determine whether glslang is present
+ option(OGRE_BUILD_COMPONENT_OVERLAY "Build Overlay component" TRUE)
+ 
++option(OGRE_WITH_FREETYPE "Build with freetype" FALSE)
++option(OGRE_WITH_QT "Build with QT support" FALSE)
++option(OGRE_WITH_SDL "Build with SDL2 support" FALSE)
++
+ cmake_dependent_option(OGRE_BUILD_COMPONENT_OVERLAY_IMGUI "Include dear imgui in Overlays" TRUE "OGRE_BUILD_COMPONENT_OVERLAY" FALSE)
+ 
+ cmake_dependent_option(OGRE_BUILD_COMPONENT_BITES "Build OgreBites component" TRUE "OGRE_BUILD_COMPONENT_OVERLAY" FALSE)
+diff --git a/Components/Overlay/CMakeLists.txt b/Components/Overlay/CMakeLists.txt
+index e12e53a3f..88732fc6c 100644
+--- a/Components/Overlay/CMakeLists.txt
++++ b/Components/Overlay/CMakeLists.txt
+@@ -19,7 +19,7 @@ list(APPEND HEADER_FILES
+ file(GLOB SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+ 
+ if(OGRE_BUILD_COMPONENT_OVERLAY_IMGUI)
+-  set(IMGUI_DIR "${PROJECT_BINARY_DIR}/imgui-1.91.9b" CACHE PATH "")
++  set(IMGUI_DIR "${PROJECT_BINARY_DIR}/imgui" CACHE PATH "")
+   if(NOT EXISTS ${IMGUI_DIR})
+     message(STATUS "Downloading imgui")
+     file(DOWNLOAD
+@@ -34,7 +34,7 @@ if(OGRE_BUILD_COMPONENT_OVERLAY_IMGUI)
+     ${IMGUI_DIR}/imgui_tables.cpp
+     ${IMGUI_DIR}/imgui_widgets.cpp
+     ${IMGUI_DIR}/imgui_demo.cpp)
+-  if(FREETYPE_FOUND)
++  if(OGRE_WITH_FREETYPE)
+     set(IMGUI_ENABLE_FREETYPE TRUE)
+     list(APPEND SOURCE_FILES ${IMGUI_DIR}/misc/freetype/imgui_freetype.cpp)
+   endif()
+@@ -50,7 +50,7 @@ target_include_directories(OgreOverlay PUBLIC
+   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+   $<INSTALL_INTERFACE:include/OGRE/Overlay>)
+ 
+-if(FREETYPE_FOUND)
++if(OGRE_WITH_FREETYPE)
+   target_compile_definitions(OgreOverlay PRIVATE HAVE_FREETYPE)
+   target_link_libraries(OgreOverlay PRIVATE ${FREETYPE_LIBRARIES})
+   target_include_directories(OgreOverlay PRIVATE ${FREETYPE_INCLUDE_DIRS})
+@@ -61,6 +61,10 @@ elseif(UNIX)
+   set_source_files_properties(src/OgreFont.cpp PROPERTIES
+     COMPILE_FLAGS "-Wno-cast-qual -Wno-unused-function")
+ endif()
++if(OGRE_WITH_QT)
++  # workaround a linking issue with BitesQT
++  target_link_libraries(OgreOverlay PUBLIC PNG::PNG BZip2::BZip2)
++endif()
+ 
+ if(OGRE_BUILD_COMPONENT_OVERLAY_IMGUI)
+   target_include_directories(OgreOverlay PUBLIC
+@@ -78,7 +82,7 @@ if(OGRE_BUILD_COMPONENT_OVERLAY_IMGUI)
+     set_source_files_properties(${IMGUI_DIR}/imgui.cpp PROPERTIES
+       COMPILE_FLAGS "-Wno-cast-qual -Wno-unused-variable")
+     set_source_files_properties(${IMGUI_DIR}/imgui_demo.cpp PROPERTIES
+-      COMPILE_FLAGS "-Wno-cast-qual")
++      COMPILE_FLAGS "-Wno-cast-qual -Wno-format-truncation")
+     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+       set_property(SOURCE ${IMGUI_DIR}/misc/freetype/imgui_freetype.cpp
+         APPEND PROPERTY COMPILE_OPTIONS "-Wno-unknown-warning-option")
+diff --git a/PlugIns/Assimp/CMakeLists.txt b/PlugIns/Assimp/CMakeLists.txt
+index 3dc686ae3..3325902f3 100644
+--- a/PlugIns/Assimp/CMakeLists.txt
++++ b/PlugIns/Assimp/CMakeLists.txt
+@@ -5,7 +5,7 @@ add_library(Codec_Assimp ${OGRE_LIB_TYPE} ${HEADER_FILES} src/AssimpLoader.cpp)
+ target_include_directories(Codec_Assimp PUBLIC
+     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+     $<INSTALL_INTERFACE:include/OGRE/Plugins/Assimp>)
+-target_link_libraries(Codec_Assimp PUBLIC OgreMain fix::assimp)
++target_link_libraries(Codec_Assimp PUBLIC OgreMain assimp::assimp)
+ 
+ if(OGRE_BUILD_COMPONENT_RTSHADERSYSTEM)
+     target_link_libraries(Codec_Assimp PUBLIC OgreRTShaderSystem)
+diff --git a/PlugIns/FreeImageCodec/CMakeLists.txt b/PlugIns/FreeImageCodec/CMakeLists.txt
+index 1721957cd..8508db942 100644
+--- a/PlugIns/FreeImageCodec/CMakeLists.txt
++++ b/PlugIns/FreeImageCodec/CMakeLists.txt
+@@ -14,10 +14,10 @@ set(SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/OgreFreeImageCodec.cpp")
+ add_definitions(-DFREEIMAGE_LIB)
+ add_library(Codec_FreeImage ${OGRE_LIB_TYPE} ${HEADER_FILES} ${SOURCES})
+ target_link_libraries(Codec_FreeImage PUBLIC OgreMain ${FreeImage_LIBRARIES})
+-target_include_directories(Codec_FreeImage PUBLIC 
++target_include_directories(Codec_FreeImage PUBLIC
+     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+-    $<INSTALL_INTERFACE:include/OGRE/Plugins/FreeImageCodec>
+-    PRIVATE "${FreeImage_INCLUDE_DIR}")
++    PRIVATE
++    $<INSTALL_INTERFACE:include/OGRE/Plugins/FreeImageCodec>)
+ 
+ if (MINGW)
+   # may need winsock htons functions for FreeImage
+diff --git a/PlugIns/GLSLang/CMakeLists.txt b/PlugIns/GLSLang/CMakeLists.txt
+index 17844605c..04bfb7826 100644
+--- a/PlugIns/GLSLang/CMakeLists.txt
++++ b/PlugIns/GLSLang/CMakeLists.txt
+@@ -13,30 +13,17 @@ if(ANDROID)
+         ${ANDROID_NDK}/sources/third_party/shaderc/third_party/)
+     target_link_libraries(Plugin_GLSLangProgramManager PUBLIC OgreMain
+         ${ANDROID_NDK}/sources/third_party/shaderc/libs/c++_static/${ANDROID_ABI}/libshaderc.a)
+-elseif(DEFINED ENV{VULKAN_SDK})
+-    message(STATUS "Using VULKAN_SDK: $ENV{VULKAN_SDK}")
+-    target_include_directories(Plugin_GLSLangProgramManager SYSTEM PRIVATE $ENV{VULKAN_SDK}/include)
+-    target_link_directories(Plugin_GLSLangProgramManager PUBLIC $ENV{VULKAN_SDK}/lib)
+-    target_link_libraries(Plugin_GLSLangProgramManager PUBLIC OgreMain shaderc_combined)
+-else()
+-  set(GLSLANG_LIBS glslang SPIRV SPIRV-Tools-opt SPIRV-Tools)
+-  find_library(GLSLANG_OSDependent OSDependent)
+-  if(GLSLANG_OSDependent)
+-    set(GLSLANG_LIBS ${GLSLANG_LIBS} ${GLSLANG_OSDependent})
+-  endif()
+-  find_library(GLSLANG_HLSL HLSL)
+-  if(GLSLANG_HLSL)
+-    set(GLSLANG_LIBS ${GLSLANG_LIBS} ${GLSLANG_HLSL})
+-  endif()
+-  find_library(GLSLANG_OGLCompiler OGLCompiler)
+-  if(GLSLANG_OGLCompiler)
+-    set(GLSLANG_LIBS ${GLSLANG_LIBS} ${GLSLANG_OGLCompiler})
++elseif(WIN32)
++  if(TARGET Vulkan::Vulkan)
++    target_link_libraries(Plugin_GLSangProgramManager PRIVATE Vulkan::Vulkan Vulkan::Headers Vulkan::Registry)
+   endif()
+-  find_library(GLSLANG_MI MachineIndependent)
+-  if(GLSLANG_MI)
+-      set(GLSLANG_LIBS ${GLSLANG_MI} GenericCodeGen ${GLSLANG_LIBS})
+-  endif()
+-  target_link_libraries(Plugin_GLSLangProgramManager PUBLIC OgreMain ${GLSLANG_LIBS})
++  target_link_libraries(Plugin_GLSLangProgramManager PUBLIC
++    OgreMain
++    glslang::glslang glslang::HLSL glslang::OSDependent glslang::OGLCompiler glslang::SPIRV SPIRV-Tools-static SPIRV-Tools-opt)
++else()
++  target_link_libraries(Plugin_GLSLangProgramManager PUBLIC
++    OgreMain
++    glslang::glslang glslang::HLSL glslang::OSDependent glslang::OGLCompiler glslang::SPIRV SPIRV-Tools-static SPIRV-Tools-opt)
+ endif()
+ ogre_config_framework(Plugin_GLSLangProgramManager)
+ ogre_config_plugin(Plugin_GLSLangProgramManager)
+diff --git a/RenderSystems/Vulkan/CMakeLists.txt b/RenderSystems/Vulkan/CMakeLists.txt
+index ae9340b72..ffe63b00e 100755
+--- a/RenderSystems/Vulkan/CMakeLists.txt
++++ b/RenderSystems/Vulkan/CMakeLists.txt
+@@ -18,10 +18,7 @@ set( SOURCE_FILES ${SOURCE_FILES})
+ 
+ add_library(RenderSystem_Vulkan ${OGRE_LIB_TYPE} ${HEADER_FILES} ${SOURCE_FILES})
+ 
+-if(DEFINED ENV{VULKAN_SDK})
+-    target_include_directories(RenderSystem_Vulkan SYSTEM PRIVATE $ENV{VULKAN_SDK}/include)
+-    target_link_directories(RenderSystem_Vulkan PUBLIC $ENV{VULKAN_SDK}/lib)
+-endif()
++target_link_libraries(RenderSystem_Vulkan PRIVATE Vulkan::Vulkan Vulkan::Headers Vulkan::Registry)
+ 
+ if(WIN32)
+     target_compile_definitions(RenderSystem_Vulkan PRIVATE VK_USE_PLATFORM_WIN32_KHR)
+diff --git a/Tests/CMakeLists.txt b/Tests/CMakeLists.txt
+index 6df997c22..783ef58f8 100644
+--- a/Tests/CMakeLists.txt
++++ b/Tests/CMakeLists.txt
+@@ -10,7 +10,7 @@
+ # Configure Tests build
+ if (OGRE_BUILD_TESTS)
+ 
+-  if(NOT EXISTS ${PROJECT_BINARY_DIR}/googletest-1.16.0)
++  if(FALSE)
+     message(STATUS "Building gtest")
+     file(DOWNLOAD
+         https://github.com/google/googletest/releases/download/v1.16.0/googletest-1.16.0.tar.gz
+diff --git a/Tools/AssimpConverter/CMakeLists.txt b/Tools/AssimpConverter/CMakeLists.txt
+index 8f40b8442..482254544 100644
+--- a/Tools/AssimpConverter/CMakeLists.txt
++++ b/Tools/AssimpConverter/CMakeLists.txt
+@@ -9,7 +9,7 @@
+ 
+ add_executable(OgreAssimpConverter main.cpp)
+ target_link_libraries(OgreAssimpConverter OgreMain OgreRTShaderSystem)
+-target_include_directories(OgreAssimpConverter PRIVATE $<TARGET_PROPERTY:fix::assimp,INTERFACE_INCLUDE_DIRECTORIES>)
++target_include_directories(OgreAssimpConverter PRIVATE $<TARGET_PROPERTY:assimp::assimp,INTERFACE_INCLUDE_DIRECTORIES>)
+ if (OGRE_PROJECT_FOLDERS)
+ 	set_property(TARGET OgreAssimpConverter PROPERTY FOLDER Tools)
+ endif ()
+-- 
+2.39.5
+


### PR DESCRIPTION
Add latest release of Ogre v14.4.1, with latest available dependencies (not tested against, e.g. Qt).
Compared to Ogres build system, Assimp is on a lower major version and should be bumped to 6 once available on CCI.

Replace msvc 193 with msvc 194 due to CI version availability.